### PR TITLE
fix possible double freeing

### DIFF
--- a/rtemstoolkit/rld-path.cpp
+++ b/rtemstoolkit/rld-path.cpp
@@ -116,6 +116,7 @@ namespace rld
           if (!::getcwd (buf, 32 * 1024))
           {
             delete [] buf;
+            buf = 0;
             throw rld::error (::strerror (errno), "get current working directory");
           }
           path_join (buf, path, apath);


### PR DESCRIPTION
the final handler will cause the array to be freed again.